### PR TITLE
Advandced search updates

### DIFF
--- a/grails-app/controllers/uk/org/nbn/biocache/hubs/OccurrenceController.groovy
+++ b/grails-app/controllers/uk/org/nbn/biocache/hubs/OccurrenceController.groovy
@@ -8,8 +8,10 @@ class OccurrenceController extends au.org.ala.biocache.hubs.OccurrenceController
     @Override
     def list(SpatialSearchRequestParams requestParams) {
         String[] fq = params.list("fq") as String[] //what ALA do to override Grails (handles fq=<empty string>)
+        String q = params.getOrDefault("q","")
+        String defaultFilterExclusionPattern = grailsApplication.config.facets.defaultFiltersQueryExclusionPattern
 
-        if(fq.length == 0 && grailsApplication.config.facets.defaultFilters){
+        if(fq.length == 0 && grailsApplication.config.facets.defaultFilters && !(defaultFilterExclusionPattern != null && q ==~ /$defaultFilterExclusionPattern/)){
 //            requestParams.fq = grailsApplication.config.facets.defaultFilters.toString().split(',')
 //            requestParams.fq = ['occurrence_status:"present"', '-user_assertions:(50001 OR 50005 OR 50006)']
             params.put('fq',grailsApplication.config.facets.defaultFilters.toString().split(','));

--- a/grails-app/controllers/uk/org/nbn/hub/OccurrenceSearchController.groovy
+++ b/grails-app/controllers/uk/org/nbn/hub/OccurrenceSearchController.groovy
@@ -10,14 +10,6 @@ class OccurrenceSearchController {
         return redirect(controller: 'occurrences', action: 'search', params: [q:"occurrence_id:"+occurrenceID])
     }
 
-    def searchByEventID(String eventID) {
-        return redirect(controller: 'occurrences', action: 'search', params: [q:"event_id:"+eventID])
-    }
-
-    def searchByCollectionCode(String collectionCode) {
-        return redirect(controller: 'occurrences', action: 'search', params: [q:"collection_code:"+collectionCode])
-    }
-
     def searchByOther(AdvancedSearchParams requestParams) {
         Map paramMap = requestParams.toParamMap();
        // paramMap.put("sort","score")

--- a/grails-app/controllers/uk/org/nbn/hub/UrlMappings.groovy
+++ b/grails-app/controllers/uk/org/nbn/hub/UrlMappings.groovy
@@ -12,8 +12,6 @@ class UrlMappings {
 
         "/"(controller: 'home')
         "/advancedSearch/searchByOccurrenceID"(controller: 'occurrenceSearch', action: 'searchByOccurrenceID')
-        "/occurrences/searchByEventID"(controller: 'occurrenceSearch', action: 'searchByEventID')
-        "/occurrences/searchByCollectionCode"(controller: 'occurrenceSearch', action: 'searchByCollectionCode')
         "/advancedSearch/searchByOther"(controller: 'occurrenceSearch', action: 'searchByOther')
         "/accessControl/filterEditor/$dpuid/$filterUserId/$filterId?"(controller: 'accessControl', action: 'filterEditor')
         "500"(view:'/error')

--- a/grails-app/controllers/uk/org/nbn/hub/UrlMappings.groovy
+++ b/grails-app/controllers/uk/org/nbn/hub/UrlMappings.groovy
@@ -11,10 +11,10 @@ class UrlMappings {
 
 
         "/"(controller: 'home')
-        "/occurrences/searchByOccurrenceID"(controller: 'occurrenceSearch', action: 'searchByOccurrenceID')
+        "/advancedSearch/searchByOccurrenceID"(controller: 'occurrenceSearch', action: 'searchByOccurrenceID')
         "/occurrences/searchByEventID"(controller: 'occurrenceSearch', action: 'searchByEventID')
         "/occurrences/searchByCollectionCode"(controller: 'occurrenceSearch', action: 'searchByCollectionCode')
-        "/occurrences/searchByOther"(controller: 'occurrenceSearch', action: 'searchByOther')
+        "/advancedSearch/searchByOther"(controller: 'occurrenceSearch', action: 'searchByOther')
         "/accessControl/filterEditor/$dpuid/$filterUserId/$filterId?"(controller: 'accessControl', action: 'filterEditor')
         "500"(view:'/error')
         "404"(view:'/notFound')

--- a/grails-app/views/home/_advanced.gsp
+++ b/grails-app/views/home/_advanced.gsp
@@ -18,7 +18,7 @@
 
 <div class="nbn">
 
-    <form class="form-horizontal" action="${request.contextPath}/occurrences/searchByOccurrenceID" method="POST">
+    <form class="form-horizontal" action="${request.contextPath}/advancedSearch/searchByOccurrenceID" method="POST">
 
         <fieldset>
             <legend>Search by Occurrence ID</legend>
@@ -39,7 +39,7 @@
     </form>
 
     <form class="form-horizontal" name="advancedSearchForm" id="advancedSearchForm"
-          action="${request.contextPath}/occurrences/searchByOther" method="POST" id="advancedSearchForm">
+          action="${request.contextPath}/advancedSearch/searchByOther" method="POST" id="advancedSearchForm">
         <input type="hidden" name="nameType"
                value="${grailsApplication.config.advancedTaxaField ?: 'matched_name_children'}"/>
 

--- a/grails-app/views/home/_advanced.gsp
+++ b/grails-app/views/home/_advanced.gsp
@@ -1,5 +1,5 @@
 <%@ page contentType="text/html;charset=UTF-8" %>
-<%@ page import="uk.org.nbn.hub.HubType" %>
+<%@ page import="uk.org.nbn.hub.AdvancedSearchParams; uk.org.nbn.hub.HubType" %>
 <g:render template="/layouts/global"/>
 
 %{--TODO: get the layers url with the layerid (below) into a config file--}%
@@ -80,6 +80,18 @@
                 <div class="col-md-6">
                     <input type="text" value="" id="taxonID" name="taxonID" class="form-control" size="60"
                            placeholder="e.g. NHMSYS0000376154">
+                </div>
+            </div>
+
+            <% def occurrenceStatuses =  [AdvancedSearchParams.ALL_OPTION] + AdvancedSearchParams.OCCURRENCE_STATUS_OPTIONS %>
+            <div class="form-group">
+                <label class="col-md-2 control-label">Occurrence Status</label>
+                <div class="col-md-6 radio">
+                    <% occurrenceStatuses.eachWithIndex { status, index -> %>
+                    <label class="radio">
+                        <g:radio name="occurrenceStatus" value="${status}" checked="${status.equalsIgnoreCase("present")}" /> ${status}
+                    </label>
+                    <% } %>
                 </div>
             </div>
 

--- a/src/main/groovy/uk/org/nbn/hub/AdvancedSearchParams.groovy
+++ b/src/main/groovy/uk/org/nbn/hub/AdvancedSearchParams.groovy
@@ -276,6 +276,9 @@ class AdvancedSearchParams implements Validateable {
     private String buildGridReferenceGB(gridReference) {
         String query = "";
         switch (gridReference.length()) {
+            case 2:
+                query = "grid_ref_100000:" + gridReference;
+                break;
             case 4:
                 query = "grid_ref_10000:" + gridReference;
                 break;
@@ -298,6 +301,9 @@ class AdvancedSearchParams implements Validateable {
     private String buildGridReferenceIrish(gridReference) {
         String query = "";
         switch (gridReference.length()) {
+            case 1:
+                query = "grid_ref_100000:" + gridReference;
+                break;
             case 3:
                 query = "grid_ref_10000:" + gridReference;
                 break;

--- a/src/main/groovy/uk/org/nbn/hub/AdvancedSearchParams.groovy
+++ b/src/main/groovy/uk/org/nbn/hub/AdvancedSearchParams.groovy
@@ -57,7 +57,7 @@ class AdvancedSearchParams implements Validateable {
     String habitatTaxon = ""
     String eventID = ""
     String collectionCode = ""
-
+    String occurrenceStatus = ""
 
     private String taxa = ""
     private final String QUOTE = "\""
@@ -65,6 +65,8 @@ class AdvancedSearchParams implements Validateable {
     private List queryItems = [];
     private List filterQueryItems = [];
 
+    public static final ALL_OPTION = "All"
+    public static final OCCURRENCE_STATUS_OPTIONS = ["Present", "Absent"]
     /**
      * This custom toString method outputs a valid /occurrence/search query string.
      *
@@ -91,7 +93,7 @@ class AdvancedSearchParams implements Validateable {
         addQueryItem(buildTaxonIDQuery(taxonID))
         addQueryItem(buildEventIDQuery(eventID))
         addQueryItem(buildCollectionCodeQuery(collectionCode))
-
+        addFilterQueryItem(buildOccurrenceStatusQuery(occurrenceStatus))
 
         String encodedQ = queryItems.join(" ${BOOL_OP} ").toString().trim()
         String encodedTaxa;
@@ -368,7 +370,18 @@ class AdvancedSearchParams implements Validateable {
         return collectionCode?"collection_code:\""+collectionCode+"\"":"";
     }
 
+    private String buildOccurrenceStatusQuery(String occurrenceStatus) {
+        String query="";
 
+        if (occurrenceStatus?.equalsIgnoreCase(ALL_OPTION)){
+            query = "occurrence_status:*"
+        }
+        else if(OCCURRENCE_STATUS_OPTIONS*.toLowerCase().contains(occurrenceStatus?.toLowerCase())){
+            query = "occurrence_status:${occurrenceStatus.toLowerCase()}"
+        }
+
+        return query;
+    }
 
 
     private void addQueryItem(String queryString) {


### PR DESCRIPTION
### Fixes:

https://nbnatlas.atlassian.net/browse/ATLASDEV-2001
https://nbnatlas.atlassian.net/browse/ATLASDEV-2002
https://nbnatlas.atlassian.net/browse/ATLASDEV-2003
https://nbnatlas.atlassian.net/browse/ATLASDEV-2005

### Notes:

I think that the other two search related routes in UrlMappings.groovy are redundant and can be removed along with their respective methods as I couldn't find reference to them. I have left them for the minute though.

-  "/occurrences/searchByEventID"(controller: 'occurrenceSearch', action: 'searchByEventID')
-  "/occurrences/searchByCollectionCode"(controller: 'occurrenceSearch', action: 'searchByCollectionCode')

The config property `defaultFilterExclusionPattern` would for the most part be set to the below but needs checking on the country hubs (especially inns-records) hence not provided default. The alternative is that this will be made redundant by data-quality-service:

`facets.defaultFiltersQueryExclusionPattern=occurrence_id:.*`