### PR TITLE
BibliographicCitation to occurrence record page

### DIFF
--- a/grails-app/services/uk/org/nbn/biocache/hubs/WebServicesService.groovy
+++ b/grails-app/services/uk/org/nbn/biocache/hubs/WebServicesService.groovy
@@ -59,4 +59,10 @@ class WebServicesService extends au.org.ala.biocache.hubs.WebServicesService{
         def url = "${grailsApplication.config.alerts.baseUrl}" + "/api/savedSearch/list/" + userId
         getJsonElements(url, "${grailsApplication.config.alerts.apiKey}")
     }
+
+     // @Cacheable('collectoryCache')
+    def JSONObject getDataresource(String id) {
+        def url = "${grailsApplication.config.collections.baseUrl}/ws/dataResource/" + id
+        getJsonElements(url)
+    }
 }

--- a/grails-app/taglib/uk/org/nbn/biocache/hubs/OccurrenceTagLib.groovy
+++ b/grails-app/taglib/uk/org/nbn/biocache/hubs/OccurrenceTagLib.groovy
@@ -8,6 +8,8 @@ class OccurrenceTagLib extends au.org.ala.biocache.hubs.OccurrenceTagLib{
 
     static namespace = 'alatag'
 
+    def webServicesService
+
     /**
      * Output a row (occurrence record) in the search results "Records" tab
      *
@@ -204,6 +206,44 @@ class OccurrenceTagLib extends au.org.ala.biocache.hubs.OccurrenceTagLib{
 
         // Output modal HTML directly to the page
         out << g.render(template: '/occurrence/wmsModal', model: [targetSelector: targetSelector])
+    }
+
+    /**
+     * Formats and displays a bibliographic citation with optional URL link.
+     * If citation is not provided but dataResourceUid is, it will attempt to fetch the citation from the data resource.
+     *
+     * @attr citation OPTIONAL the bibliographic citation text
+     * @attr citationUrl OPTIONAL the URL to link the citation to
+     * @attr dataResourceUid OPTIONAL the UID to fetch citation from if not directly provided
+     */
+    def bibliographicCitation = { attrs ->
+        def mb = new MarkupBuilder(out)
+        def citation = attrs.citation
+        def citationUrl = attrs.citationUrl
+        def dataResourceUid = attrs.dataResourceUid
+
+        // If no citation but we have a dataResourceUid, try to fetch it
+        if (!citation && dataResourceUid) {
+            def dataResource = webServicesService.getDataresource(dataResourceUid)
+            if (dataResource) {
+                citation = dataResource.citation
+                citationUrl = dataResource.alaPublicUrl
+            } else {
+                citation = "Not found"
+            }
+        }
+
+        if (citation) {
+            if (citationUrl) {
+                mb.a(href: citationUrl, target: "_blank") {
+                    mkp.yieldUnescaped(citation)
+                }
+            } else {
+                mb.span {
+                    mkp.yieldUnescaped(citation)
+                }
+            }
+        }
     }
 
 }

--- a/grails-app/views/occurrence/_recordCore.gsp
+++ b/grails-app/views/occurrence/_recordCore.gsp
@@ -401,6 +401,16 @@
             </g:else>
         </alatag:occurrenceTableRow>
 
+    <!-- Bibliographic Citation -->
+    <alatag:occurrenceTableRow annotate="false" section="dataset" fieldCode="bibliographicCitation" fieldName="Bibliographic Citation">
+        ${fieldsMap.put("bibliographicCitation", true)}
+        ${fieldsMap.put("bibliographicCitationUrl", true)}
+        <alatag:bibliographicCitation
+            citation="${record.raw.occurrence.bibliographicCitation}"
+            citationUrl="${record.raw.occurrence.bibliographicCitationUrl}"
+            dataResourceUid="${record.raw.attribution.dataResourceUid}"/>
+    </alatag:occurrenceTableRow>
+
     <!-- Collection Code -->
         <alatag:occurrenceTableRow annotate="false" section="dataset" fieldNameIsMsgCode="true" fieldCode="collectionCode" fieldName="Collection">
             <g:if test="${record.raw.occurrence.collectionCode}">


### PR DESCRIPTION
This PR contains the changes for this ticket - https://nbnatlas.atlassian.net/browse/BACKLOG-266

- Add bibliographic citation tag to OccurrenceTagLib
- Introduced a new method in OccurrenceTagLib to format and display bibliographic citations, with optional URL linking.
- Integrated the new citation functionality into the occurrence record view, allowing for dynamic fetching of citations based on data resource UID.
- Added a new service method in WebServicesService to retrieve data resource information.
- Updated the GSP view to include a new row for bibliographic citations in the occurrence table.