### PR TITLE
Added OGC mapping to URL

### DIFF
--- a/grails-app/views/occurrence/_wmsModal.gsp
+++ b/grails-app/views/occurrence/_wmsModal.gsp
@@ -247,7 +247,8 @@ function updateWmsModalContent() {
     var currentLayer = MAP_VAR.currentLayers[0];
     if (currentLayer) {
         var wmsParams = currentLayer.wmsParams;
-        var baseUrl = MAP_VAR.mappingUrl + MAP_VAR.query;
+        // Added /ogc/ows to the mappingUrl to match the WMS GetCapabilities request URL
+        var baseUrl = MAP_VAR.mappingUrl + "/ogc/ows" + MAP_VAR.query;
 
         // Parse existing ENV parameters
         let envParams = {};


### PR DESCRIPTION
Added OGC mapping to WMS Url - generates a GetCapabilities document based on a query  that can be used in an OGC client. See - https://github.com/nbnuk/biocache-service/blob/7c84d112a1b9d79ff137ac60f29b6d2bb7a1dcb5/src/main/webapp/WEB-INF/jsp/oldapi.jsp#L428


Dialog now has this:
![image](https://github.com/user-attachments/assets/4f170b23-95b4-4071-b48a-c6742e3ef5e1)


