### PR TITLE
Frontend reformat of habitatsTaxon

### DIFF
--- a/grails-app/assets/javascripts/show-override.js
+++ b/grails-app/assets/javascripts/show-override.js
@@ -204,4 +204,20 @@ function refreshUserAnnotations(){
     });
 }
 
+/**
+ * re-formats an unquoted json like array string e.g.[a,b]
+ */
+function reformatListValueString(selector,seperator) {
+    var value = $(selector).text().trim();
+    if(!value) return;
+
+    var match = value.match(/^\[\s*(.*?)\s*\]$/);
+    if (match) {
+        var listContent = match[1]; // Extract content inside brackets
+        var items = listContent.split(/\s*,\s*/); // Split by commas, ignoring spaces
+        $(selector).text(items.join(seperator));
+    }
+}
+
 refreshUserAnnotations();
+reformatListValueString('#habitatsTaxon .value', '|');


### PR DESCRIPTION
habitatsTaxon was displayed in json like list [ habitat, habitat ] (as stored in solr) whereas previously habitatTaxon displayed as habitat|habitat (as stored in cassandra).

JS frontend reformatted to match previous format, although we could delimitate with a comma instead.